### PR TITLE
UX425JA working with symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This python driver has been tested and works fine for these asus versions at the
 - TM420 (with % and = symbols)
 - UM433DA (with % and = symbols)
 - UX425EA (with % and = symbols)
+- UX425JA (with % and = symbols)
 - UX434FA (with % and = symbols)
 - UX433 (without extra symbols)
 - UX431F (without extra symbols)


### PR DESCRIPTION
FIXES:
Some miner documentation fixes.

COMMENTS:
Asus Zenbook 14" UX425JA works well with = and % symbols.