### PR TITLE
added D413IA to the list of working devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 | Model/Layout = ux433fa          | Model/Layout = m433ia   | Model/Layout = ux581l |
 | ![without % = symbols](https://github.com/mohamed-badaoui/ux433-touchpad-numpad/blob/main/images/Asus-ZenBook-UX433FA.jpg)  |  ![with % = symbols](https://github.com/mohamed-badaoui/ux433-touchpad-numpad/blob/main/images/Asus-VivoBook-M433IA.jpg) | ![model ux581](https://github.com/mohamed-badaoui/ux433-touchpad-numpad/blob/main/images/Asus-ZenBook-UX581l.jpg) |
 
-This is a python service which enables switching between numpad and touchpad for the Asus UX433. It may work for other models. When running the script, use as an argument one of the strings `ux433fa` or `m433ia` or `ux581l to select the layout that fits your touchpad. You can inspect the different layouts [here](https://github.com/mohamed-badaoui/asus-touchpad-numpad-driver/tree/main/numpad_layouts).
+This is a python service which enables switching between numpad and touchpad for the Asus UX433. It may work for other models. When running the script, use as an argument one of the strings `ux433fa` or `m433ia` or `ux581l` to select the layout that fits your touchpad. You can inspect the different layouts [here](https://github.com/mohamed-badaoui/asus-touchpad-numpad-driver/tree/main/numpad_layouts).
 
 This python driver has been tested and works fine for these asus versions at the moment:
+- D413IA (with % and = symbols)
 - M433IA (with % and = symbols)
 - R424DA (without extra symbols)
 - ROG Strix G15 2021 


### PR DESCRIPTION
Tested it with a D413IA and it works flawlessly after uncommenting [ExecStartPre=/bin/sleep 2](https://github.com/mohamed-badaoui/asus-touchpad-numpad-driver/blob/main/asus_touchpad.service#L13=) Thanks again for writing this driver. :)