### PR TITLE
Add support for ASUS UX3402ZA and dynamic brightness configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 | Model/Layout = ux433fa          | Model/Layout = m433ia   | Model/Layout = ux581l |
 | ![without % = symbols](https://github.com/mohamed-badaoui/ux433-touchpad-numpad/blob/main/images/Asus-ZenBook-UX433FA.jpg)  |  ![with % = symbols](https://github.com/mohamed-badaoui/ux433-touchpad-numpad/blob/main/images/Asus-VivoBook-M433IA.jpg) | ![model ux581](https://github.com/mohamed-badaoui/ux433-touchpad-numpad/blob/main/images/Asus-ZenBook-UX581l.jpg) |
 
-This is a python service which enables switching between numpad and touchpad for the Asus UX433. It may work for other models. When running the script, use as an argument one of the strings `ux433fa` or `m433ia` or `ux581l to select the layout that fits your touchpad. You can inspect the different layouts [here](https://github.com/mohamed-badaoui/asus-touchpad-numpad-driver/tree/main/numpad_layouts).
+This is a python service which enables switching between numpad and touchpad for the Asus UX433. It may work for other models. When running the script, use as an argument one of the strings `ux433fa`, `m433ia`, `ux581l`, or `ux3402za` to select the layout that fits your touchpad. You can inspect the different layouts [here](https://github.com/mohamed-badaoui/asus-touchpad-numpad-driver/tree/main/numpad_layouts).
 
 This python driver has been tested and works fine for these asus versions at the moment:
 - E210MA (with % and = symbols)
@@ -34,6 +34,7 @@ This python driver has been tested and works fine for these asus versions at the
 - UX363EA (with % and = symbols)
 - UX363JA (with % and = symbols)
 - UX333FA (without extra symbols)
+- UX3402ZA (with % and = symbols)
 - UX325EA (with % and = symbols)
 - UM325UA (with % and = symbols)
 - X412DA (without extra symbols)

--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -5,6 +5,7 @@ import logging
 import math
 import os
 import re
+import shutil
 import subprocess
 import sys
 from fcntl import F_SETFL, fcntl
@@ -144,24 +145,34 @@ if percentage_key != EV_KEY.KEY_5:
 udev = dev.create_uinput_device()
 
 
-# Brightness 31: Low, 24: Half, 1: Full
+# Brightness configuration dynamically loaded from layout, fallback to old defaults
+try:
+    BRIGHT_VAL = [hex(val) for val in model_layout.brightness_levels]
+except AttributeError:
+    BRIGHT_VAL = [hex(val) for val in [31, 24, 1]]
 
-BRIGHT_VAL = [hex(val) for val in [31, 24, 1]]
-
+I2C_TRANSFER = shutil.which("i2ctransfer") or "i2ctransfer"
 
 def activate_numlock(brightness):
-    numpad_cmd = "i2ctransfer -f -y " + device_id + " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 " + BRIGHT_VAL[brightness] + " 0xad"
+    numpad_cmd = I2C_TRANSFER + " -f -y " + str(device_id) + " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 " + BRIGHT_VAL[brightness] + " 0xad"
+    log.debug("Activating numlock. COMMAND: %s", numpad_cmd)
     events = [
         InputEvent(EV_KEY.KEY_NUMLOCK, 1),
         InputEvent(EV_SYN.SYN_REPORT, 0)
     ]
     udev.send_events(events)
     d_t.grab()
-    subprocess.call(numpad_cmd, shell=True)
+    
+    try:
+        output = subprocess.check_output(numpad_cmd, shell=True, stderr=subprocess.STDOUT)
+        log.debug("i2ctransfer output: %s", output)
+    except subprocess.CalledProcessError as e:
+        log.error("i2ctransfer failed with code %d. Output: %s", e.returncode, e.output)
 
 
 def deactivate_numlock():
-    numpad_cmd = "i2ctransfer -f -y " + device_id + " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 0x00 0xad"
+    numpad_cmd = I2C_TRANSFER + " -f -y " + str(device_id) + " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 0x00 0xad"
+    log.debug("Deactivating numlock. COMMAND: %s", numpad_cmd)
     events = [
         InputEvent(EV_KEY.KEY_NUMLOCK, 0),
         InputEvent(EV_SYN.SYN_REPORT, 0)
@@ -189,7 +200,7 @@ def launch_calculator():
 # status 3 = max bright
 def change_brightness(brightness):
     brightness = (brightness + 1) % len(BRIGHT_VAL)
-    numpad_cmd = "i2ctransfer -f -y " + device_id + " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 " + BRIGHT_VAL[brightness] + " 0xad"
+    numpad_cmd = I2C_TRANSFER + " -f -y " + str(device_id) + " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 " + BRIGHT_VAL[brightness] + " 0xad"
     subprocess.call(numpad_cmd, shell=True)
     return brightness
 

--- a/install.sh
+++ b/install.sh
@@ -80,6 +80,10 @@ do
             model=ux581l
             break
             ;;
+        "ux3402za" )
+            model=ux3402za
+            break
+            ;;
         "Q")
             exit 0
             ;;

--- a/numpad_layouts/ux3402za.py
+++ b/numpad_layouts/ux3402za.py
@@ -1,0 +1,19 @@
+from libevdev import EV_KEY
+
+# Number of tries to identify the interface number
+try_times = 5
+try_sleep = 0.1
+
+cols = 5
+rows = 4
+top_offset = 0.3
+
+keys = [
+    [EV_KEY.KEY_KP7, EV_KEY.KEY_KP8, EV_KEY.KEY_KP9, EV_KEY.KEY_KPSLASH, EV_KEY.KEY_BACKSPACE],
+    [EV_KEY.KEY_KP4, EV_KEY.KEY_KP5, EV_KEY.KEY_KP6, EV_KEY.KEY_KPASTERISK, EV_KEY.KEY_BACKSPACE],
+    [EV_KEY.KEY_KP1, EV_KEY.KEY_KP2, EV_KEY.KEY_KP3, EV_KEY.KEY_KPMINUS, EV_KEY.KEY_5],
+    [EV_KEY.KEY_KP0, EV_KEY.KEY_KPDOT, EV_KEY.KEY_KPENTER, EV_KEY.KEY_KPPLUS, EV_KEY.KEY_KPEQUAL]
+]
+
+# Brightness levels supported by this model
+brightness_levels = [1]


### PR DESCRIPTION
### Summary
This PR adds support for the ASUS Zenbook 14 OLED (UX3402ZA) touchpad, and introduces a backward-compatible dynamic brightness configuration system to prevent `i2ctransfer` crashes on newer model trackpads that do not support legacy hex brightness properties.

### Changes Made:
- **Added `ux3402za` layout:** Included a new NumPad layout mapping specifically for the UX3402ZA grid, alongside an update to the interactive `install.sh` menu options.
- **Dynamic Brightness Handling:** Newer touchpads (like the UX3402ZA) fail and throw an `i2ctransfer` error if passed the legacy `31` (`0x1f`) or `24` (`0x18`) brightness bytes. 
  - `asus_touchpad.py` now dynamically attempts to load a `brightness_levels` array directly from the selected `model_layout`.
  - If a layout does not specify `brightness_levels`, it safely falls back to the default `[31, 24, 1]` legacy array ensuring zero breaking changes for existing older users.
- **Improved Executable Pathing:** Swapped the hardcoded `i2ctransfer` command string with `shutil.which('i2ctransfer')` in `asus_touchpad.py`. This ensures the daemon can reliably resolve the binary's absolute path (e.g. `/usr/bin/` vs `/usr/sbin/`) across diverse distros when running headless via systemd, reducing silent failures.

### Testing:
- Tested locally on an ASUS UX3402ZA running Linux. The `0x01` brightness payload successfully lights the NumPad LEDs, and layout bindings match identically.
- Verified that README is updated to reflect support for the `UX3402ZA`.