### PR TITLE
feat: Add support for Zenbook 14 OLED (UX3405CA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This python driver has been tested and works fine for these asus versions at the
 - X412DA (without extra symbols)
 - UX581L (with % and = symbols)
 - Zephyrus S GX701 (with % and = symbols)
+- UX3405CA (with % and = symbols)
 
 Install required packages
 

--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -49,7 +49,7 @@ while tries > 0:
         lines = f.readlines()
         for line in lines:
             # Look for the touchpad #
-            if touchpad_detected == 0 and ("Name=\"ASUE" in line or "Name=\"ELAN" in line) and "Touchpad" in line:
+            if touchpad_detected == 0 and ("Name=\"ASUE" in line or "Name=\"ASUF" in line or "Name=\"ELAN" in line) and "Touchpad" in line:
                 touchpad_detected = 1
                 log.debug('Detect touchpad from %s', line.strip())
 

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,10 @@ do
             model=ux3402za
             break
             ;;
+        "ux3405ca" )
+            model=ux3405ca
+            break
+            ;;
         "Q")
             exit 0
             ;;

--- a/numpad_layouts/ux3405ca.py
+++ b/numpad_layouts/ux3405ca.py
@@ -1,0 +1,18 @@
+from libevdev import EV_KEY
+
+# Number of tries to identify the interface number
+try_times = 5
+try_sleep = 0.1
+
+cols = 5
+rows = 4
+top_offset = 0.20
+
+keys = [
+    [EV_KEY.KEY_KP7, EV_KEY.KEY_KP8, EV_KEY.KEY_KP9, EV_KEY.KEY_KPSLASH, EV_KEY.KEY_BACKSPACE],
+    [EV_KEY.KEY_KP4, EV_KEY.KEY_KP5, EV_KEY.KEY_KP6, EV_KEY.KEY_KPASTERISK, EV_KEY.KEY_BACKSPACE],
+    [EV_KEY.KEY_KP1, EV_KEY.KEY_KP2, EV_KEY.KEY_KP3, EV_KEY.KEY_KPMINUS, EV_KEY.KEY_5],
+    [EV_KEY.KEY_KP0, EV_KEY.KEY_KPDOT, EV_KEY.KEY_KPENTER, EV_KEY.KEY_KPPLUS, EV_KEY.KEY_KPEQUAL]
+]
+
+brightness_levels = [1]


### PR DESCRIPTION
First of all, thank you for this project!

I've added support for the UX3405CA model.

Changes:
Detection: Added ASUF to the discovery logic
Layout: Created ux3405ca.py
Installer: Added ux3405ca option to install.sh.

Related to #124 

Tested on Arch Linux with a UX3405CA (intel core ultra 9 285H) unit.