### PR TITLE
fix: StandardInput=tty-force causes black screen on boot

### DIFF
--- a/asus_touchpad.service
+++ b/asus_touchpad.service
@@ -4,7 +4,7 @@ Description=Asus Touchpad to Numpad Handler
 [Service]
 Type=simple
 ExecStart=/usr/share/asus_touchpad_numpad-driver/asus_touchpad.py $LAYOUT $PERCENTAGE_KEY
-StandardInput=tty-force
+StandardInput=null
 StandardOutput=/var/log/asus_touchpad_numpad-driver/error.log
 StandardError=/var/log/asus_touchpad_numpad-driver/error.log
 TimeoutSec=5


### PR DESCRIPTION
Fixes #129

Replace StandardInput=tty-force with StandardInput=null to prevent 
the service from occupying /dev/tty1 and blocking display managers 
like plasmalogin (Fedora 44 KDE).

Tested on Fedora 44 KDE with ASUS ZenBook.